### PR TITLE
<= safari 14 compatability for milo college

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -57,9 +57,9 @@ const miloLibs = setLibs(LIBS);
   });
 }());
 
-const { loadArea, loadDelayed, setConfig } = await import(`${miloLibs}/utils/utils.js`);
-
 (async function loadPage() {
+  const { loadArea, loadDelayed, setConfig } = await import(`${miloLibs}/utils/utils.js`);
+
   setConfig({ ...CONFIG, miloLibs });
   await loadArea();
   loadDelayed();


### PR DESCRIPTION
To test go to adobe.okta.com
Open Saucelabs and with Saucelabs open the URL with Safari 14

Before: https://main--milo-college--adobecom.hlx.page/
After: https://safari14-bug--milo-college--adobecom.hlx.page/

The issue was being caused because we were awaiting a promise on the top level of a module
This is only supported as of Safari 15
![Screenshot 2022-11-22 at 11 59 45](https://user-images.githubusercontent.com/115231412/203299892-73e8ef63-9941-4a98-bc53-f1502f41816c.png)
