### PR TITLE
Adding new supported config properties

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -62,6 +62,14 @@ const CONFIG = {
   // geoRouting: 'off',
   // fallbackRouting: 'off',
   // iconsExcludeBlocks: [],
+  // signInContext: { dctx_id: '' },
+  // externalLibs: [
+  //  {
+  //    base: '/path-to-libs',
+  //    blocks: ['block1', 'block2'],
+  //  },
+  // Add more in order of precedence (first match wins):
+  // ],
   decorateArea,
   locales: {
     '': { ietf: 'en-US', tk: 'hah7vzn.css' },


### PR DESCRIPTION
The request for this came from the PR review comments here: https://github.com/adobecom/milo/pull/4833
For context around externalLibs: https://github.com/orgs/adobecom/discussions/304

Besides the `externalLibs` property being a new one, I also retroactively added the signInContext property, which is the place to define custom SUSI context used across Milo components. The object to be passed to signInContext is an direct pass-on and supported properties inside the object are based on SUSI's API contract. 